### PR TITLE
nlplug-findfs: fix erratic behavior and SIGSEGV

### DIFF
--- a/nlplug-findfs.c
+++ b/nlplug-findfs.c
@@ -727,7 +727,7 @@ static int dispatch_uevent(struct uevent *ev, struct ueventconf *conf)
 			if (rc)
 				return rc;
 
-			if (searchdev(ev, conf->crypt.device, NULL, NULL)) {
+			if (conf->crypt.devnode[0] == '\0' && searchdev(ev, conf->crypt.device, NULL, NULL)) {
 				strncpy(conf->crypt.devnode,
 					conf->crypt.device[0] == '/' ? conf->crypt.device : ev->devnode,
 					sizeof(conf->crypt.devnode));


### PR DESCRIPTION
Likely introduced in the major rehaul done in
e4af128b30855b2b29a27c2fd7580b62059bbe51
