### PR TITLE
mkinitfs: add support for resume

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -263,7 +263,7 @@ set -- $(cat /proc/cmdline)
 myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm debug_init
 	dma init_args keep_apk_new modules ovl_dev pkgs quiet root_size root
 	usbdelay ip alpine_repo apkovl alpine_start splash blacklist
-	overlaytmpfs rootfstype rootflags nbd"
+	overlaytmpfs rootfstype rootflags nbd resume"
 
 for opt; do
 	case "$opt" in
@@ -371,16 +371,25 @@ if [ -n "$KOPT_root" ]; then
 	fi
 
 	ebegin "Mounting root"
+	nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root
+
+	if [ -n "$KOPT_resume" ]; then
+		echo "Resume from disk"
+		if [ -e /sys/power/resume ]; then
+			printf "%d:%d" $(stat -Lc "0x%t 0x%T" "$KOPT_resume") >/sys/power/resume
+		else
+			echo "resume: no hibernation support found"
+		fi
+	fi
+
 	if [ "$KOPT_overlaytmpfs" = "yes" ]; then
 		mkdir -p /media/root-ro /media/root-rw $sysroot/media/root-ro \
 			$sysroot/media/root-rw
-		nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root \
-			&& mount -o ro $KOPT_root /media/root-ro
+		mount -o ro $KOPT_root /media/root-ro
 		mount -t tmpfs root-tmpfs /media/root-rw
 		mkdir -p /media/root-rw/work /media/root-rw/root
 		mount -t overlay -o lowerdir=/media/root-ro,upperdir=/media/root-rw/root,workdir=/media/root-rw/work overlayfs $sysroot
 	else
-		nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root
 		mount ${KOPT_rootfstype:+-t} ${KOPT_rootfstype} \
 			-o ${KOPT_rootflags:-ro} \
 			$KOPT_root $sysroot


### PR DESCRIPTION
This patch tries to add resume from hibernation (aka suspend to disk)
support to mkinitfs. The swap partition can be provided via the resume
option.

I know this feature is mostly needed on destops/notebooks, therefore I'm
not sure if there is any interest for Alpine Linux. The default Alpine
Linux
kernel has no hibernation support compiled in, so you need to build
a custom kernel in order to test this.

These links helped me on the topic:
- https://wiki.gentoo.org/wiki/Custom_Initramfs/Hibernation
- https://git.archlinux.org/mkinitcpio.git/tree/hooks/resume

As this might be a dangerous feature I would like to get your opinions.
