### PR TITLE
Sort initramfs files before creating cpio archive

### DIFF
--- a/mkinitfs.in
+++ b/mkinitfs.in
@@ -139,7 +139,7 @@ initfs_apk_keys() {
 
 initfs_cpio() {
 	if [ -n "$list_sources" ]; then
-		(cd "$tmpdir" && find . )
+		(cd "$tmpdir" && find . | sort)
 		return
 	fi
 	rm -f $outfile

--- a/mkinitfs.in
+++ b/mkinitfs.in
@@ -144,7 +144,7 @@ initfs_cpio() {
 	fi
 	rm -f $outfile
 	umask 0022
-	(cd "$tmpdir" && find . | cpio --quiet -o -H newc | gzip -9) > $outfile
+	(cd "$tmpdir" && find . | sort | cpio --quiet -o -H newc | gzip -9) > $outfile
 }
 
 usage() {


### PR DESCRIPTION
Piping `find` to `sort` will generate consistent file/directory structures in the cpio archives, thus enabling the creation of small binary diffs (xdelta) between two initramfs files.