### PR TITLE
Update initramfs-init.in to libressl APK

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -55,7 +55,7 @@ unpack_apkovl() {
 	fi
 
 	# we need openssl. let apk handle deps
-	apk add --quiet --initdb --repositories-file $repofile openssl || return 1
+	apk add --quiet --initdb --repositories-file $repofile libressl || return 1
 
 	if ! openssl list-cipher-commands | grep "^$suffix$" > /dev/null; then
 		errstr="Cipher $suffix is not supported"


### PR DESCRIPTION
switched LBU decryption to require the libressl APK instead of the now removed (as of v3.5.0) openssl APK.

Otherwise a fresh install can not unpack an encrypted LBU used by a ram installation.