### PR TITLE
mkinitfs.conf: add kms

### DIFF
--- a/mkinitfs.conf
+++ b/mkinitfs.conf
@@ -1,2 +1,2 @@
 # run mkinitfs -L for a list of available features
-features="ata base cdrom ext2 ext3 ext4 keymap kms mmc raid scsi usb virtio"
+features="kms ata base cdrom ext2 ext3 ext4 keymap kms mmc raid scsi usb virtio"


### PR DESCRIPTION
With kms enabled we get full resolution right on the start of the boot process, instead of only in the middle after modules are loaded.