### PR TITLE
initramfs-init: fix booting from btrfs on multiple devices

### DIFF
--- a/features.d/btrfs.files
+++ b/features.d/btrfs.files
@@ -1,0 +1,1 @@
+/sbin/btrfs

--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -388,6 +388,10 @@ if [ -n "$KOPT_root" ]; then
 	nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} \
 		$KOPT_root
 
+	if echo "$KOPT_modules $KOPT_rootfstype" | grep -qw btrfs; then
+		/sbin/btrfs device scan || echo "Failed to scan devices for btrfs filesystem."
+	fi
+
 	if [ -n "$KOPT_resume" ]; then
 		echo "Resume from disk"
 		if [ -e /sys/power/resume ]; then


### PR DESCRIPTION
https://btrfs.wiki.kernel.org/index.php/Using_Btrfs_with_Multiple_Devices:
> btrfs device scan is used to scan all of the block devices under /dev
> and probe for Btrfs volumes. This is required after loading the btrfs
> module if you're running with more than one device in a filesystem.

See http://bugs.alpinelinux.org/issues/6903