### PR TITLE
init: add support for loading AWS ENA drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CONF_FILES	:= mkinitfs.conf \
 		features.d/cramfs.modules \
 		features.d/cryptsetup.files \
 		features.d/cryptsetup.modules \
+		features.d/ena.modules \
 		features.d/ext2.modules \
 		features.d/ext3.modules \
 		features.d/ext4.modules \

--- a/features.d/ena.modules
+++ b/features.d/ena.modules
@@ -1,0 +1,1 @@
+kernel/drivers/net/ethernet/amazon


### PR DESCRIPTION
This change is related to [aports pull request 2961](https://github.com/alpinelinux/aports/pull/2961) which adds the AWS EC2 Elastic Network Adapter drivers to the aports tree. These drivers are required to bring-up any new 5 series or i3 series instances.