### PR TITLE
skip hooks on diskless install

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -598,7 +598,7 @@ if [ "$KOPT_chart" = yes ]; then
 	pkgs="$pkgs acct"
 fi
 
-apkflags="--initdb --progress --force"
+apkflags="--initramfs-diskless-boot --progress"
 if [ -z "$ALPINE_REPO" ]; then
 	apkflags="$apkflags --no-network"
 else


### PR DESCRIPTION
We can not run hooks before musl and busybox is installed