### PR TITLE
handle more than 2 blacklisted modules in cmdline

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -325,7 +325,7 @@ ALPINE_REPO=${KOPT_alpine_repo}
 [ "$KOPT_quiet" = yes ] && dmesg -n 1
 
 # optional blacklist
-for i in ${KOPT_blacklist/,/ }; do
+for i in ${KOPT_blacklist//,/ }; do
 	echo "blacklist $i" >> /etc/modprobe.d/boot-opt-blacklist.conf
 done
 


### PR DESCRIPTION
example:
```sh
❯ docker run --rm -ti alpine
/ # KOPT_blacklist=igb,ixgbe,tg3
/ # for i in ${KOPT_blacklist/,/ }; do echo "blacklist $i"; done
blacklist igb
blacklist ixgbe,tg3
/ # for i in ${KOPT_blacklist//,/ }; do echo "blacklist $i"; done
blacklist igb
blacklist ixgbe
blacklist tg3
```