### PR TITLE
Add support for keyfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CONF_FILES	:= mkinitfs.conf \
 		features.d/btrfs.modules \
 		features.d/cdrom.modules \
 		features.d/cramfs.modules \
+		features.d/cryptkey.files \
 		features.d/cryptsetup.files \
 		features.d/cryptsetup.modules \
 		features.d/ena.modules \

--- a/features.d/cryptkey.files
+++ b/features.d/cryptkey.files
@@ -1,0 +1,1 @@
+/crypto_keyfile.bin

--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -267,9 +267,9 @@ setup_nbd() {
 set -- $(cat /proc/cmdline)
 
 myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader cryptoffset
-	cryptdiscards debug_init dma init_args keep_apk_new modules ovl_dev pkgs quiet
-	root_size root usbdelay ip alpine_repo apkovl alpine_start splash blacklist
-	overlaytmpfs rootfstype rootflags nbd resume"
+	cryptdiscards cryptkey debug_init dma init_args keep_apk_new modules ovl_dev
+	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
+	blacklist overlaytmpfs rootfstype rootflags nbd resume"
 
 for opt; do
 	case "$opt" in
@@ -370,6 +370,11 @@ if [ -n "$KOPT_cryptroot" ]; then
 	fi
 	if [ -n "$KOPT_cryptoffset" ]; then
 		cryptopts="$cryptopts -o ${KOPT_cryptoffset}"
+	fi
+	if [ "$KOPT_cryptkey" = "yes" ]; then
+		cryptopts="$cryptopts -k /crypto_keyfile.bin"
+	elif [ -n "$KOPT_cryptkey" ]; then
+		cryptopts="$cryptopts -k ${KOPT_cryptkey}"
 	fi
 fi
 


### PR DESCRIPTION
The `cryptkey` boot parameter enables keyfile decryption, which may be helpful for unlocking via USB key or for having to type the passphrase only once when using GRUB cryptodisk.

Usage: `cryptkey=/path/to/keyfile.bin`
If the path is omitted, `cryptkey` will attempt to use `/crypto_keyfile.bin` by default.

If keyfile decryption fails, init will fall back to passphrase mode.