### PR TITLE
initramfs-init: add support for ssh installer

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -183,6 +183,8 @@ configure_ip() {
 	local netmask="$4"
 	local device="$6"
 	local autoconf="$7"
+	local dns1="$8"
+	local dns2="$9"
 	case "$client_ip" in
 		off|none|'') return;;
 		dhcp) autoconf="dhcp";;
@@ -209,6 +211,8 @@ configure_ip() {
 		ebegin "Setting IP ($device)..."
 		ip_set "$device" "$client_ip" "$netmask" "$gw_ip"
 		eend $?
+		[ -n "$dns1" ] && echo "nameserver $dns1" >> /etc/resolv.conf
+		[ -n "$dns2" ] && echo "nameserver $dns2" >> /etc/resolv.conf
 	fi
 	MAC_ADDRESS=$(cat /sys/class/net/$device/address)
 }
@@ -262,6 +266,19 @@ setup_nbd() {
 	[ "$n" != 0 ] || return 1
 }
 
+# possible cmdline options which could have secure urls.
+# this does not include apkovl as it need to be fetched inside of initramfs
+need_wget() {
+	local opt= ret=1
+	for opt in modloop ssh_key; do
+		eval "opt=\$KOPT_$opt"
+		case "$opt" in
+			https://*|ftps://*) ret=0;;
+		esac
+	done
+	return $ret
+}
+
 # read the kernel options. we need surve things like:
 #  acpi_osi="!Windows 2006" xen-pciback.hide=(01:00.0)
 set -- $(cat /proc/cmdline)
@@ -269,7 +286,7 @@ set -- $(cat /proc/cmdline)
 myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader cryptoffset
 	cryptdiscards debug_init dma init_args keep_apk_new modules ovl_dev pkgs quiet
 	root_size root usbdelay ip alpine_repo apkovl alpine_start splash blacklist
-	overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd"
+	overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key ssh_pass"
 
 for opt; do
 	case "$opt" in
@@ -345,20 +362,20 @@ mount -t devpts -o gid=5,mode=0620,noexec,nosuid devpts /dev/pts
 [ -d /dev/shm ] || mkdir /dev/shm
 mount -t tmpfs -o nodev,nosuid,noexec shm /dev/shm
 
-if [ -n "$dasd" ]; then
+if [ -n "$KOPT_dasd" ]; then
 	for mod in dasd_mod dasd_eckd_mod dasd_fba_mod; do
 		modprobe $mod
 	done
-	for _dasd in $(echo "$dasd" | tr ',' ' ' ); do
+	for _dasd in $(echo "$KOPT_dasd" | tr ',' ' ' ); do
 		echo 1 > /sys/bus/ccw/devices/"${_dasd%%:*}"/online
 	done
 fi
 
-if [ "${s390x_net%%,*}" = "qeth_l2" ]; then
+if [ "${KOPT_s390x_net%%,*}" = "qeth_l2" ]; then
 	for mod in qeth qeth_l2 qeth_l3; do
 		modprobe $mod
 	done
-	_channel="${s390x_net#*,}"
+	_channel="${KOPT_s390x_net#*,}"
 	echo "$_channel" > /sys/bus/ccwgroup/drivers/qeth/group
 	echo 1 > /sys/bus/ccwgroup/drivers/qeth/"${_channel%%,*}"/layer2
 	echo 1 > /sys/bus/ccwgroup/drivers/qeth/"${_channel%%,*}"/online
@@ -540,6 +557,8 @@ if [ -f "$sysroot/etc/.default_boot_services" -o ! -f "$ovl" ]; then
 	rc_add killprocs shutdown
 	rc_add savecache shutdown
 
+	rc_add firstboot default
+
 	rm -f "$sysroot/etc/.default_boot_services"
 fi
 
@@ -621,6 +640,14 @@ ebegin "Installing packages to root filesystem"
 if [ "$KOPT_chart" = yes ]; then
 	pkgs="$pkgs acct"
 fi
+
+# add openssh
+if [ -n "$KOPT_ssh_key" ] || [ -n "$KOPT_ssh_pass" ]; then
+	pkgs="$pkgs openssh"
+fi
+
+# add wget if using secure urls in cmdline
+need_wget && pkgs="$pkgs wget"
 
 apkflags="--initramfs-diskless-boot --progress"
 if [ -z "$ALPINE_REPO" ]; then


### PR DESCRIPTION
This commit allows running the Alpine installer through SSH either
using a SSH key or a password. Allowing root access through SSH must
be revoked before finishing running setup-disk as this config would
leak to new system.

On s390x, the boot media consist of a kernel, an initramfs, and a
parm file. We don't necessarily need a modloop image and fetch
initial packages from remote repo instead. This behavior is the same
on other distros.