### PR TITLE
Use first network interface that is up

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -145,8 +145,11 @@ setup_inittab_console(){
 # uses the first "eth" interface.
 ip_choose_if() {
 	for x in /sys/class/net/eth*; do
-		[ -e "$x" ] && echo ${x##*/} && return
+		if grep -iq up $x/operstate;then
+			[ -e "$x" ] && echo ${x##*/} && return
+		fi
 	done
+	[ -e "$x" ] && echo ${x##*/} && return
 }
 
 # ip_set <device> <ip> <netmask> <gateway-ip>


### PR DESCRIPTION
Previous code would return eth0 every time and pay no attention
if interface was up. This patch gets the state from operstate file
in sysfs to use the interface that is actually up in case there
are multiple interfaces present. If no interface is up, just use
last interface.