### PR TITLE
Add a new Kernel command to allow ssh public key to be obtained via http

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -276,7 +276,8 @@ set -- $(cat /proc/cmdline)
 myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader cryptoffset
 	cryptdiscards cryptkey debug_init dma init_args keep_apk_new modules ovl_dev
 	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
-	blacklist overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key"
+	blacklist overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key
+	ssh_key_plain"
 
 for opt; do
 	case "$opt" in
@@ -637,7 +638,7 @@ if [ "$KOPT_chart" = yes ]; then
 fi
 
 # add openssh
-if [ -n "$KOPT_ssh_key" ]; then
+if [ -n "$KOPT_ssh_key" ] || [ -n "$KOPT_ssh_key_plain" ]; then
 	pkgs="$pkgs openssh"
 	rc_add sshd default
 fi

--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -145,8 +145,11 @@ setup_inittab_console(){
 # uses the first "eth" interface.
 ip_choose_if() {
 	for x in /sys/class/net/eth*; do
-		[ -e "$x" ] && echo ${x##*/} && return
+		if grep -iq up $x/operstate;then
+			[ -e "$x" ] && echo ${x##*/} && return
+		fi
 	done
+	[ -e "$x" ] && echo ${x##*/} && return
 }
 
 # ip_set <device> <ip> <netmask> <gateway-ip>


### PR DESCRIPTION
`ssh_key` kernel command requires https or ftps. This patch introduces a new kernel command called ssh_key_plain which would allow a user to download their SSH public key via http. An exmaple being:
`ssh_key_plain=http://mykey`
This would be helpful for a local network install and will require an additional patch in firstboot to allow this new kernel command. 