### PR TITLE
Add a new Kernel command to allow ssh public key to be obtained via http (fixed commits)

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -276,7 +276,8 @@ set -- $(cat /proc/cmdline)
 myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader cryptoffset
 	cryptdiscards cryptkey debug_init dma init_args keep_apk_new modules ovl_dev
 	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
-	blacklist overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key"
+	blacklist overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key
+	ssh_key_plain"
 
 for opt; do
 	case "$opt" in
@@ -637,7 +638,7 @@ if [ "$KOPT_chart" = yes ]; then
 fi
 
 # add openssh
-if [ -n "$KOPT_ssh_key" ]; then
+if [ -n "$KOPT_ssh_key" ] || [ -n "$KOPT_ssh_key_plain" ]; then
 	pkgs="$pkgs openssh"
 	rc_add sshd default
 fi


### PR DESCRIPTION
`ssh_key` kernel command requires https or ftps. This patch introduces a new kernel command called ssh_key_plain which would allow a user to download their SSH public key via http. An exmaple being:
`ssh_key_plain=http://mykey`
This would be helpful for a local network install and will require an additional patch in firstboot to allow this new kernel command. Firstboot discussion here: https://github.com/alpinelinux/aports/pull/4563 thank you to @tmh1999 for patch proposal. 

Signed-off-by: Mick Tarsel <mtarsel@gmail.com>