### PR TITLE
[WIP] initramfs-init: Always configure network when ip= is given

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -412,8 +412,11 @@ if [ -n "$KOPT_cryptroot" ]; then
 	fi
 fi
 
-if [ -n "$KOPT_nbd" ]; then
+if [ -n "$KOPT_ip" ]; then
 	configure_ip
+fi
+
+if [ -n "$KOPT_nbd" ]; then
 	setup_nbd || echo "Failed to setup nbd device."
 fi
 


### PR DESCRIPTION
Previously, only alpine_repo= and apkovl= triggered the configuration
of the network. Not using them caused the ip= parameter to be ignored.

The invocations of configure_ip for said two options were not removed
because network configuration may still be triggered by the options
named above.  The function itself is safe to be invoked multiple times.