### PR TITLE
Reuse kernel-side configuration for console= devices

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -105,34 +105,28 @@ rc_add() {
 	ln -sf /etc/init.d/$1 $sysroot/etc/runlevels/$2/$1
 }
 
+# Recursively resolve tty aliases like console or tty0
+list_console_devices() {
+	if ! [ -e /sys/class/tty/$1/active ]; then
+		echo $1
+		return
+	fi
+
+	for dev in $(cat /sys/class/tty/$1/active); do
+		list_console_devices $dev
+	done
+}
+
 setup_inittab_console(){
-	while [ $# -gt 0 ]; do
-		local tty=${1%,*}
-		local speed=${1#*,}
-		local line=
-		local term=
-		case "$tty" in
-			ttyS*|ttyMFD*|ttyUSB*|ttyAMA*)
-				term=vt100
-				line=-L
-				flow=${speed##*[^r]}
-				speed=${speed%%[^0-9]*}
-				speed=${speed:-115200}
-				;;
-			*)
-				[ "$speed" = "$1" ] && speed=38400
-				;;
-		esac
-		shift
-
-		# skip "current console" from being added to inittab
-		[ "$tty" = "tty0" ] && continue
-
+	term=vt100
+	# Inquire the kernel for list of console= devices
+	for tty in $(list_console_devices console); do
 		# do nothing if inittab already have the tty set up
 		if ! grep -q "^$tty:" $sysroot/etc/inittab; then
 			echo "# enable login on alternative console" \
 				>> $sysroot/etc/inittab
-			echo "$tty::respawn:/sbin/getty ${flow:+-h }$line $speed $tty $term" \
+			# Baudrate of 0 keeps settings from kernel
+			echo "$tty::respawn:/sbin/getty -L 0 $tty $term" \
 				>> $sysroot/etc/inittab
 		fi
 		if [ -e "$sysroot"/etc/securetty ] && ! grep -q -w "$tty" "$sysroot"/etc/securetty; then
@@ -290,10 +284,6 @@ for opt; do
 	case "$opt" in
 	s|single|1)
 		SINGLEMODE=yes
-		continue
-		;;
-	console=*)
-		CONSOLE="$CONSOLE ${opt#console=}"
 		continue
 		;;
 	esac
@@ -707,7 +697,7 @@ if [ -f "$sysroot"/etc/fstab ]; then
 fi
 
 # fix inittab if alternative console
-setup_inittab_console $CONSOLE
+setup_inittab_console
 
 # copy alpine release info
 #if ! [ -f "$sysroot"/etc/alpine-release ] && [ -f $ALPINE_MNT/.alpine-release ]; then


### PR DESCRIPTION
Instead of parsing the console= options in the initramfs, we ask the
kernel of its interpretation of the console= parameters. The kernel
does the console setup as part of its early startup, including the
configuration of the baud rate, control bits and flow control.

The options and format of the console= parameter are documented here:
https://www.kernel.org/doc/html/v4.15/admin-guide/serial-console.html

By keeping the settings from the kernel, we avoid baud rate switching
between printk and getty output on edge cases.

This adds support for additional tty types, like hvc, while removing
string parsing code from the initramfs.

This supersedes #32.