### PR TITLE
Deprecate nodma boot parameter

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -329,11 +329,6 @@ if [ "$KOPT_chart" = yes ]; then
 	eend 0
 fi
 
-# dma can be problematic
-if [ "$KOPT_dma" = no ]; then
-	modprobe libata dma=0
-fi
-
 # The following values are supported:
 #   alpine_repo=auto         -- default, search for .boot_repository
 #   alpine_repo=http://...   -- network repository

--- a/mkinitfs-bootparam.7.in
+++ b/mkinitfs-bootparam.7.in
@@ -59,9 +59,6 @@ DHCP.
 \fBmodules=\fIMODULE\fR{,\fIMODULE\fR}
 Comma-sparated list of kernel modules to load explicitly.
 .TP
-\fBnodma\fR
-Disable DMA for ATA devices.
-.TP
 \fBoverlaytmpfs\fR
 When booting from an read-only partition, you can specify this flag to have
 your changes written to an in-memory overlayfs.


### PR DESCRIPTION
The kernel offers the same functionality through `libata.dma=0` boot parameter.

I do intend to have `nodma` removed on a later release so there is an transition period.

I'm owner of affected hardware, so i have means to run further tests regarding this issue.