### PR TITLE
Make fetching the DMI uuid fail silently

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -524,7 +524,7 @@ if [ -z "$KOPT_apkovl" ]; then
 	fi
 elif is_url "$KOPT_apkovl"; then
 	# Fetch apkovl via network
-	MACHINE_UUID=$(cat /sys/class/dmi/id/product_uuid)
+	MACHINE_UUID=$(cat /sys/class/dmi/id/product_uuid 2>/dev/null)
 	url="${KOPT_apkovl/{MAC\}/$MAC_ADDRESS}"
 	url="${url/{UUID\}/$MACHINE_UUID}"
 	ovl=/tmp/${url##*/}


### PR DESCRIPTION
This flag does not exist on most non-x86 platforms.