### PR TITLE
Cleanup and improve documentation for ip= parameter

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -146,14 +146,6 @@ ip_choose_if() {
 	[ -e "$x" ] && echo ${x##*/} && return
 }
 
-# ip_set <device> <ip> <netmask> <gateway-ip>
-ip_set() {
-	ifconfig "$1" "$2" netmask "$3" || return $?
-	if [ -n "$4" ]; then
-		ip route add 0.0.0.0/0 via "$4" dev "$1" || return $?
-	fi
-}
-
 # if "ip=dhcp" is specified on the command line, we obtain an IP address
 # using udhcpc. we do this now and not by enabling kernel-mode DHCP because
 # kernel-model DHCP appears to require that network drivers be built into
@@ -162,19 +154,24 @@ ip_set() {
 #
 # You need af_packet.ko available as well modules for your Ethernet card.
 #
+# See https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+# for documentation on the format.
+#
 # Valid syntaxes:
-#   ip=client-ip:server-ip:gw-ip:netmask:hostname:device:autoconf
+#   ip=client-ip:server-ip:gw-ip:netmask:hostname:device:autoconf:
+#     :dns0-ip:dns1-ip:ntp0-ip
 #   ip=dhcp
-#   "server-ip" and "hostname" are not supported here.
+#   "server-ip", "hostname" and "ntp0-ip" are not supported here.
 # Default (when configure_ip is called without setting ip=):
 #   ip=dhcp
 #
 configure_ip() {
 	[ -n "$MAC_ADDRESS" ] && return
-	local ops=${KOPT_ip:-dhcp}
+
 	local IFS=':'
-	set -- $ops
+	set -- ${KOPT_ip:-dhcp}
 	unset IFS
+
 	local client_ip="$1"
 	local gw_ip="$3"
 	local netmask="$4"
@@ -182,16 +179,19 @@ configure_ip() {
 	local autoconf="$7"
 	local dns1="$8"
 	local dns2="$9"
+
 	case "$client_ip" in
-		off|none|'') return;;
+		off|none) return;;
 		dhcp) autoconf="dhcp";;
 	esac
 
 	[ -n "$device" ] || device=$(ip_choose_if)
+
 	if [ -z "$device" ]; then
 		echo "ERROR: IP requested but no network device was found"
 		return 1
 	fi
+
 	if [ "$autoconf" = "dhcp" ]; then
 		# automatic configuration
 		if [ ! -e /usr/share/udhcpc/default.script ]; then
@@ -199,18 +199,24 @@ configure_ip() {
 			return 1
 		fi
 		ebegin "Obtaining IP via DHCP ($device)..."
-		ifconfig $device 0.0.0.0
-		udhcpc -i $device -f -q
+		ifconfig "$device" 0.0.0.0
+		udhcpc -i "$device" -f -q
 		eend $?
 	else
 		# manual configuration
 		[ -n "$client_ip" -a -n "$netmask" ] || return
 		ebegin "Setting IP ($device)..."
-		ip_set "$device" "$client_ip" "$netmask" "$gw_ip"
+		if ifconfig "$device" "$client_ip" netmask "$netmask"; then
+			[ -z "$gw_ip" ] || ip route add 0.0.0.0/0 via "$gw_ip" dev "$device"
+		fi
 		eend $?
-		[ -n "$dns1" ] && echo "nameserver $dns1" >> /etc/resolv.conf
-		[ -n "$dns2" ] && echo "nameserver $dns2" >> /etc/resolv.conf
 	fi
+
+	# Never executes if variables are empty
+	for i in $dns1 $dns2; do
+		echo "nameserver $i" >> /etc/resolv.conf
+	done
+
 	MAC_ADDRESS=$(cat /sys/class/net/$device/address)
 }
 

--- a/mkinitfs-bootparam.7.in
+++ b/mkinitfs-bootparam.7.in
@@ -50,11 +50,12 @@ Print debug information during boot.
 \fBinit_args=\fIARGUMENTS\fR
 Additional command like arguments for \fI/sbin/init\fR.
 .TP
-\fBip=\fICLIENT-IP\fR::\fIGATEWAY-IP\fR:\fINETMASK\fR::\fIINTERFACE\fR
-Specify the network configuration as a colon-separated list of variable length.
-The 3rd and the 5th list item is ignored. The format is compatible with the
-SYSAPPEND option of syslinux. Use \fBip=dhcp\fR for automatic configuration via
-DHCP.
+\fBip=\fICLIENT-IP\fR:\fISERVER-IP\fR:\fIGATEWAY-IP\fR:\fINETMASK\fR:\fIHOSTNAME\fR:\fIDEVICE\fR:\fIAUTOCONF\fR:\fIDNS-IP\fR:\fIDNS-IP\fR:\fINTP-IP\fR
+Specify the network configuration. The format is equivalent to the linux kernel
+option with the same name. Per default, the \fISERVER-IP\fR, \fIHOSTNAME\fR and
+\fINTP-IP\fR parameters are ignored by the initramfs. Consult the kernel
+documentation on \fInfsroot\fR for further information regarding the fields of
+this parameter.
 .TP
 \fBmodules=\fIMODULE\fR{,\fIMODULE\fR}
 Comma-sparated list of kernel modules to load explicitly.


### PR DESCRIPTION
Functional differences:

- Networking is done if client-ip is empty, but autoconf is set to dhcp.
- DNS Servers are now set up when specified, not only for static configuration

Future changes here might be hostname and ntp support. The latter is necessary for fetching apkovl via https from an raspberry pi or other devices without rtc.