### PR TITLE
add xenpci feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ CONF_FILES	:= mkinitfs.conf \
 		features.d/ubifs.modules \
 		features.d/usb.modules \
 		features.d/virtio.modules \
+		features.d/xenpci.modules \
 		features.d/xfs.files \
 		features.d/xfs.modules \
 		features.d/zfs.files \

--- a/features.d/xenpci.modules
+++ b/features.d/xenpci.modules
@@ -1,0 +1,1 @@
+kernel/drivers/pci/xen-pcifront.ko


### PR DESCRIPTION
Add a xenpci feature needed for xen driver domains that needs PCI devices
already in initramfs.

This is for instance needed for a xen storage driver domain hosting its rootfs
on a pci passthrough SAS controller.

Example `/etc/mkinitfs/mkinitfs.conf` for a storage driver domain (after this change) with rootfs on md+lvm (/boot provided by dom0)

```
features="ata base ide scsi usb virtio ext4 xenpci lvm raid"
```