### PR TITLE
init: add support for s390x installation on LPAR

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -93,6 +93,8 @@ rc_add() {
 
 # Recursively resolve tty aliases like console or tty0
 list_console_devices() {
+	[ "$1" = "ttyS0" ] && [ -e /sys/class/tty/sclp_line0 ] && return
+
 	if ! [ -e /sys/class/tty/$1/active ]; then
 		echo $1
 		return
@@ -100,6 +102,10 @@ list_console_devices() {
 
 	for dev in $(cat /sys/class/tty/$1/active); do
 		list_console_devices $dev
+	done
+
+	for _tty in hvc0 xvc0 hvsi0 sclp_line0 ttysclp0 "3270!tty1"; do
+		[ -e /sys/class/tty/$_tty ] && echo $_tty
 	done
 }
 


### PR DESCRIPTION
In QEMU/KVM, ttysclp0 (ttyS1) is automatically detected and used by
default.
In z/VM, ttyS0 is still used instead of ttysclp0/sclp_line0, however.
In LPAR, ttyS0 is mapped to sclp_line0 as expected.

This patch detects if we are running in LPAR mode and change ttyS0 to
sclp_line0 accordingly. /proc/sysinfo is s390x specific.