### PR TITLE
Add missing return to ip_choose_if

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -128,7 +128,7 @@ ip_choose_if() {
 		mac=$(printf "%s\n" "$KOPT_BOOTIF"|sed 's/^01-//;s/-/:/g')
 		dev=$(grep -l $mac /sys/class/net/*/address|head -n 1)
 		dev=${dev%/*}
-		[ -n "$dev" ] && echo "${dev##*/}"
+		[ -n "$dev" ] && echo "${dev##*/}" && return
 	fi
 	for x in /sys/class/net/eth*; do
 		if grep -iq up $x/operstate;then


### PR DESCRIPTION
Right now, when `$KOPT_BOOTIF` is specified, it can echo a device related
to that option and still continue with the loop that checks the
operstate. Due to this, it can echo two network interfaces. This pr
fixes that so it will only return a single network interface.