### PR TITLE
Support multiple encrypted devices

### DIFF
--- a/features.d/keyctl.files
+++ b/features.d/keyctl.files
@@ -1,0 +1,1 @@
+/bin/keyctl

--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -347,7 +347,7 @@ myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader crypt
 	cryptdiscards cryptkey debug_init dma init init_args keep_apk_new modules ovl_dev
 	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
 	blacklist overlaytmpfs overlaytmpfsflags rootfstype rootflags nbd resume s390x_net
-	dasd ssh_key BOOTIF zfcp"
+	dasd ssh_key BOOTIF zfcp luksuuid lukskeydesc"
 
 for opt; do
 	case "$opt" in
@@ -364,7 +364,7 @@ for opt; do
 
 	for i in $myopts; do
 		case "$opt" in
-		$i=*)	eval "KOPT_${i}"='${opt#*=}';;
+		$i=*)	eval "KOPT_${i}=\${KOPT_${i}:+\$KOPT_${i} }${opt#*=}";;
 		$i)	eval "KOPT_${i}=yes";;
 		no$i)	eval "KOPT_${i}=no";;
 		esac
@@ -491,6 +491,18 @@ if [ -n "$KOPT_cryptroot" ]; then
 		cryptopts="$cryptopts -k ${KOPT_cryptkey}"
 	fi
 fi
+
+if [ -n "$KOPT_lukskeydesc" ]; then
+	read -s -p "Passphrase for key $KOPT_lukskeydesc: "
+	echo -n "$REPLY" | /bin/keyctl padd user "$KOPT_lukskeydesc" @u
+fi
+
+for uuid in $KOPT_luksuuid; do
+	nlplug-findfs $cryptopts -p /sbin/mdev ${KOPT_debug_init:+-d} UUID=$uuid
+        dev=$(findfs UUID=$uuid)
+        echo "Unlocking $dev as luks-$uuid"
+	/sbin/cryptsetup open $dev luks-$uuid
+done
 
 if [ -n "$KOPT_nbd" ]; then
 	# TODO: Might fail because nlplug-findfs hasn't plugged eth0 yet


### PR DESCRIPTION
I use btrfs on multiple LUKS-encrypted disks. In order to support single password entry, I have a keyfile that is a LUKS-encrypted image that, once decrypted, also decrypts the other volumes.

I made some changes to init to support this. I feel they're in line with the current design and don't interfere with other use cases. Let me know if I should make any changes to support this goal.

1. `cryptkey=...` has special behavior if the key matches `*.img`: We'll treat it as a LUKS-encrypted file (with embedded header), and try to unlock it. We use the unlocked key as a later `cryptkey` argument. **Note**: I couldn't figure out a way to get `nlplug-findfs` to do this with a single invocation, so I invoke cryptsetup directly, so it needs to be included as a feature. However I still need to invoke `nlplug-findfs` to do hotplugging, for e.g. USB keyboards to enter the passphrase, so I do a "no-op" `nlplug-findfs`.

2. `cryptroot=...` supports multiple arguments. If multiple arguments are detected, we unlock each explicitly with `nlplug-findfs`.

3. We now support multiple entries of a single argument, e.g. `cryptroot=UUID=a cryptroot=UUID=b`. This will accumulate the arguments joined by whitespace, such that `KOPT_cryptroot="UUID=a UUID=b"`. This matches the way one passes multiple arg entries to the kernel, so hopefully it makes sense to users.

**Note**: I made change 3 really because the apparent intended use was broken for me. Code comments imply that I should be able to pass `cryptroot="UUID=a UUID=b"`. I did this in my grub.cfg and verified it in the command list at boot time, but once booted, `/proc/cmdline` looked like `... "cryptroot=UUID=a UUID=b" ...`, and init did not parse this as intended. I'm not sure if this is a known bug. I'm using grub-efi-2.02-r14 and linux-vanilla-4.19.41-r0.