### PR TITLE
nlplug-findfs.c: Explicitly include sys/sysmacros.h due to musl 1.1.23 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION		:= 3.4.3
+VERSION		:= 3.4.4
 
 sbindir		?= /sbin
 sysconfdir	?= /etc/mkinitfs

--- a/nlplug-findfs.c
+++ b/nlplug-findfs.c
@@ -29,6 +29,7 @@
 #include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/wait.h>


### PR DESCRIPTION
http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of `sys/sysmacros.h` from `sys/types.h` causing mkinitfs to fail compilation against must 1.1.23 or newer.