### PR TITLE
Support multiple comma separated alpine_repo

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -239,7 +239,7 @@ relocate_mount() {
 # find the dirs under ALPINE_MNT that are boot repositories
 find_boot_repositories() {
 	if [ -n "$ALPINE_REPO" ]; then
-		echo "$ALPINE_REPO"
+		echo "$ALPINE_REPO" | tr ',' '\n'
 	else
 		find /media/* -name .boot_repository -type f -maxdepth 3 \
 			| sed 's:/.boot_repository$::'


### PR DESCRIPTION
When setting alpine_repo you can only specify one repository.

This adds a simple usage of tr so that a comma separated list
of repositories can be specified.