### PR TITLE
add feature rpirtc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ CONF_FILES	:= mkinitfs.conf \
 		features.d/raid.files \
 		features.d/raid.modules \
 		features.d/reiserfs.modules \
+		features.d/rpirtc.modules \
 		features.d/scsi.modules \
 		features.d/squashfs.modules \
 		features.d/ubifs.modules \

--- a/features.d/rpirtc.modules
+++ b/features.d/rpirtc.modules
@@ -1,0 +1,1 @@
+kernel/drivers/rtc/rtc-ds1307.ko


### PR DESCRIPTION
Add new feature rpi rtc allowing a hw rtc to be used.

The init script in Alpine Linux since v3.9 looks for `/dev/rtc`, if
not found it will switch to swclock.

To make this check work on a Rasberry PI with a mounted rtc and
the following in usercfg.txt
 `dtoverlay=i2c-rtc,ds3231`
we must have rtc drivers available already initramfs.