### PR TITLE
Helping parsing code survive variable settings with (xxx,yyy) in them

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -346,7 +346,7 @@ for opt; do
 
 	for i in $myopts; do
 		case "$opt" in
-		$i=*)	eval "KOPT_${i}=${opt#*=}";;
+		$i=*)	eval "KOPT_${i}"='${opt#*=}';; 
 		$i)	eval "KOPT_${i}=yes";;
 		no$i)	eval "KOPT_${i}=no";;
 		esac


### PR DESCRIPTION
Passing any variable to the init that contains (xxx,yyy) inside will make init break. Hopefully this change makes parsing robust against a lot of errors like that.