### PR TITLE
Current kernels use ext4 for ext2/3, which requires crypto/crc32*

### DIFF
--- a/features.d/ext2.modules
+++ b/features.d/ext2.modules
@@ -1,1 +1,3 @@
-kernel/fs/ext2
+kernel/arch/*/crypto/crc32*
+kernel/crypto/crc32*
+kernel/fs/ext4

--- a/features.d/ext3.modules
+++ b/features.d/ext3.modules
@@ -1,1 +1,3 @@
+kernel/arch/*/crypto/crc32*
+kernel/crypto/crc32*
 kernel/fs/ext4


### PR DESCRIPTION
Without this if you run setup-alpine with ROOTFS set to ext2/3, you're rewarded with a recovery prompt on first boot, as the correct kernel modules are missing.