### PR TITLE
initramfs-init: add cmdline consoles to inittab

### DIFF
--- a/initramfs-init.in
+++ b/initramfs-init.in
@@ -106,7 +106,8 @@ list_console_devices() {
 setup_inittab_console(){
 	term=vt100
 	# Inquire the kernel for list of console= devices
-	for tty in $(list_console_devices console); do
+	consoles="$(for c in console $KOPT_consoles; do list_console_devices $c; done)"
+	for tty in $consoles; do
 		# do nothing if inittab already have the tty set up
 		if ! grep -q "^$tty:" $sysroot/etc/inittab; then
 			echo "# enable login on alternative console" \
@@ -334,7 +335,7 @@ myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm cryptheader crypt
 	cryptdiscards cryptkey debug_init dma init init_args keep_apk_new modules ovl_dev
 	pkgs quiet root_size root usbdelay ip alpine_repo apkovl alpine_start splash
 	blacklist overlaytmpfs rootfstype rootflags nbd resume s390x_net dasd ssh_key
-	BOOTIF"
+	console BOOTIF"
 
 for opt; do
 	case "$opt" in
@@ -342,6 +343,9 @@ for opt; do
 		SINGLEMODE=yes
 		continue
 		;;
+	console=*)
+		opt="${opt#*=}"
+		KOPT_consoles="${opt%%,*} $KOPT_consoles"
 	esac
 
 	for i in $myopts; do


### PR DESCRIPTION
Sometimes a console is specified on the kernel command line but doesn't
get initialized by the kernel because for example the driver is built as
a module. The init should still spawn getty on it.